### PR TITLE
Fix corrupted copyright symbol in version info on rlottlie.dll

### DIFF
--- a/vs2019/rlottie.rc
+++ b/vs2019/rlottie.rc
@@ -1,5 +1,6 @@
 // Microsoft Visual C++ generated resource script.
 //
+#pragma code_page(65001)
 #include "resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
@@ -17,7 +18,6 @@
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
-#pragma code_page(1252)
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Overview
Use `#pragma code_page(65001)` for copyright symbol. The copyright symbol was getting corrupted on the version info on the file.

**Before**
<image src="https://user-images.githubusercontent.com/5382895/113343236-8de66580-92fd-11eb-9cea-80cab72b6750.png" width=400>

**After**
<image src="https://user-images.githubusercontent.com/5382895/113343871-5e842880-92fe-11eb-8a9f-e65c703d80d7.png" width=400>

The copyright range is also incorrect. It should be using 2021 only (it specifies `COPYRIGHT_NOTICE( 2021 )`), but the versioning happens in the consuming Luma repo, so that'll be fixed separately.

