### PR TITLE
Used Same Version File

### DIFF
--- a/vs2019/rlottie.rc
+++ b/vs2019/rlottie.rc
@@ -50,7 +50,7 @@ END
 // Version
 //
 
-#include "version.h"
+#include <LumaVersion.h>
 
 VS_VERSION_INFO VERSIONINFO
  FILEVERSION FILEVER

--- a/vs2019/rlottie.vcxproj
+++ b/vs2019/rlottie.vcxproj
@@ -37,9 +37,11 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(SolutionDir)CommonPropertyMacros.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(SolutionDir)CommonPropertyMacros.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -62,6 +64,9 @@
     <Link>
       <SubSystem>Console</SubSystem>
     </Link>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>$(LUMA_VERSION_INCLUDE)</AdditionalIncludeDirectories>
+    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -84,6 +89,9 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>$(LUMA_VERSION_INCLUDE)</AdditionalIncludeDirectories>
+    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\inc\rlottie.h" />


### PR DESCRIPTION
## Introduction

`rlottie.dll` we put the TechSmith copyright and version on it; here is a screenshot from CS 2020:
![image](https://user-images.githubusercontent.com/3475163/121378828-894bb800-c911-11eb-9966-03ab5e4e807f.png)

So instead of using a separate `version.h` included from the `.rc` file; these changes have it use the same version header file as the rest of Luma (Companion, CSRenderLib, DecoderLib, etc).

## Testing Notes

I made an installer with some other changes and it looks as it did before:
![image](https://user-images.githubusercontent.com/3475163/121379481-0d9e3b00-c912-11eb-83ed-6c1331bdeb41.png)

Hope that helps! :smiley: