### PR TITLE
CMake: Specify public include folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ set(LOTTIE_MODULE_PATH "${CMAKE_SHARED_LIBRARY_PREFIX}rlottie-image-loader${CMAK
 
 configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake/config.h.in config.h)
 
+target_include_directories(rlottie PUBLIC
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+   $<INSTALL_INTERFACE:inc>
+)
+
 target_include_directories(rlottie
     PRIVATE
         "${CMAKE_CURRENT_BINARY_DIR}"


### PR DESCRIPTION
Specify public include folder so CMake targets that want to link against rlottie only need to do `target_link_libraries(target PRIVATE rlottie` and no longer need to `target_link_directories(target PRIVATE path/to/rlottie/inc)`