### PR TITLE
Replacement colors

### DIFF
--- a/inc/rlottie.h
+++ b/inc/rlottie.h
@@ -487,6 +487,9 @@ public:
      */
     ~Animation();
 
+    std::vector<Color> colorPalette() const;
+    void setReplacementColors(const std::vector<Color>& replacementColors);
+   
 private:
     void setValue(Color_Type, Property, const std::string &, Color);
     void setValue(Float_Type, Property, const std::string &, float);

--- a/src/lottie/lottieanimation.cpp
+++ b/src/lottie/lottieanimation.cpp
@@ -153,7 +153,11 @@ void AnimationImpl::setReplacementColors( const std::vector<Color> &replacementC
   {
       updatedReplacementColors.emplace_back( model::Color(color.r(), color.g(), color.b()) );
   }
-  mReplacementColors = updatedReplacementColors;
+  if (updatedReplacementColors != mReplacementColors)
+  {
+     mReplacementColors = updatedReplacementColors;
+     mRenderer->setDirty();
+  }
 }
 
 #ifdef LOTTIE_THREAD_SUPPORT

--- a/src/lottie/lottieanimation.cpp
+++ b/src/lottie/lottieanimation.cpp
@@ -70,13 +70,16 @@ public:
     const MarkerList &markers() const { return mModel->markers(); }
     void              setValue(const std::string &keypath, LOTVariant &&value);
     void              removeFilter(const std::string &keypath, Property prop);
-
+    std::vector<Color> colorPalette() const;
+    void setReplacementColors(const std::vector<Color> &replacementColors);
+   
 private:
     mutable LayerInfoList                  mLayerList;
     model::Composition *                   mModel;
     SharedRenderTask                       mTask;
     std::atomic<bool>                      mRenderInProgress;
     std::unique_ptr<renderer::Composition> mRenderer{nullptr};
+    std::vector<model::Color>              mReplacementColors;
 };
 
 void AnimationImpl::setValue(const std::string &keypath, LOTVariant &&value)
@@ -108,6 +111,7 @@ bool AnimationImpl::update(size_t frameNo, const VSize &size,
 Surface AnimationImpl::render(size_t frameNo, const Surface &surface,
                               bool keepAspectRatio)
 {
+    model::Color::s_ReplacementColors = mReplacementColors;
     bool renderInProgress = mRenderInProgress.load();
     if (renderInProgress) {
         vCritical << "Already Rendering Scheduled for this Animation";
@@ -130,6 +134,26 @@ void AnimationImpl::init(std::shared_ptr<model::Composition> composition)
     mModel = composition.get();
     mRenderer = std::make_unique<renderer::Composition>(composition);
     mRenderInProgress = false;
+}
+
+std::vector<Color> AnimationImpl::colorPalette() const
+{
+    std::vector<Color> result;
+    for (const auto &color : mModel->mColorPalette)
+    {
+        result.emplace_back(Color(color.r, color.g, color.b));
+    }
+    return result;
+}
+
+void AnimationImpl::setReplacementColors( const std::vector<Color> &replacementColors )
+{
+  std::vector<model::Color> updatedReplacementColors;
+  for (const auto &color : replacementColors)
+  {
+      updatedReplacementColors.emplace_back( model::Color(color.r(), color.g(), color.b()) );
+  }
+  mReplacementColors = updatedReplacementColors;
 }
 
 #ifdef LOTTIE_THREAD_SUPPORT
@@ -445,6 +469,16 @@ Surface::Surface(uint32_t *buffer, size_t width, size_t height,
 {
     mDrawArea.w = mWidth;
     mDrawArea.h = mHeight;
+}
+
+std::vector<Color> Animation::colorPalette() const
+{
+    return d->colorPalette();
+}
+
+void Animation::setReplacementColors( const std::vector<Color> &replacementColors )
+{
+    d->setReplacementColors(replacementColors);
 }
 
 void Surface::setDrawRegion(size_t x, size_t y, size_t width, size_t height)

--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All rights reserved.
 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -1488,4 +1488,10 @@ void renderer::Repeater::renderList(std::vector<VDrawable *> &list)
 {
     if (mHidden) return;
     return renderer::Group::renderList(list);
+}
+
+void renderer::Composition::setDirty()
+{
+    mCurFrameNo = -1;
+    mRootLayer->setDirty();
 }

--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -196,6 +196,7 @@ public:
     const LOTLayerNode *renderTree() const;
     bool                render(const rlottie::Surface &surface);
     void                setValue(const std::string &keypath, LOTVariant &value);
+    void                setDirty();
 
 private:
     SurfaceCache                        mSurfaceCache;
@@ -241,6 +242,7 @@ public:
     const char *                 name() const { return mLayerData->name(); }
     virtual bool resolveKeyPath(LOTKeyPath &keyPath, uint32_t depth,
                                 LOTVariant &value);
+    virtual void setDirty() { mDirtyFlag = DirtyFlagBit::All; }
 
 protected:
     virtual void   preprocessStage(const VRect &clip) = 0;
@@ -281,7 +283,13 @@ public:
 protected:
     void preprocessStage(const VRect &clip) final;
     void updateContent() final;
-
+    void setDirty() override
+    {
+       Layer::setDirty();
+       for ( auto layer : mLayers )
+          layer->setDirty();
+    }
+   
 private:
     void renderHelper(VPainter *painter, const VRle &mask, const VRle &matteRle,
                       SurfaceCache &cache);

--- a/src/lottie/lottiemodel.cpp
+++ b/src/lottie/lottiemodel.cpp
@@ -363,3 +363,5 @@ std::vector<LayerInfo> model::Composition::layerInfoList() const
 
     return result;
 }
+
+std::vector<model::Color> model::Color::s_ReplacementColors;

--- a/src/lottie/lottiemodel.h
+++ b/src/lottie/lottiemodel.h
@@ -77,11 +77,17 @@ public:
     }
     friend inline Color operator+(const Color &c1, const Color &c2);
     friend inline Color operator-(const Color &c1, const Color &c2);
-
+    bool operator==(const Color color) const
+    {
+       return r == color.r && g == color.g && b == color.b;
+    }
+   
 public:
     float r{1};
     float g{1};
     float b{1};
+    int paletteNumber{-1};
+    static std::vector<Color> s_ReplacementColors;
 };
 
 inline Color operator-(const Color &c1, const Color &c2)
@@ -328,7 +334,15 @@ public:
 
     T value(int frameNo) const
     {
-        return isStatic() ? value() : animation().value(frameNo);
+       auto result = isStatic() ? value() : animation().value(frameNo);
+       if constexpr (std::is_same<T, Color>::value)
+       {
+          if (result.paletteNumber >= 0 && result.paletteNumber < Color::s_ReplacementColors.size())
+          {
+             return Color::s_ReplacementColors[result.paletteNumber];
+          }
+       }
+       return result;
     }
 
     // special function only for type T=PathData
@@ -570,6 +584,7 @@ public:
     std::vector<Marker> mMarkers;
     VArenaAlloc         mArenaAlloc{2048};
     Stats               mStats;
+    std::vector<Color>  mColorPalette;
 };
 
 class Transform : public Object {

--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -217,6 +217,8 @@ public:
 
     std::shared_ptr<model::Composition> composition() const
     {
+        if (mComposition)
+           mComposition->mColorPalette = mPalette;
         return mComposition;
     }
     void             parseComposition();
@@ -362,6 +364,20 @@ private:
         }
     } mPathInfo;
 
+    void addColorToPalette(model::Color & color)
+    {
+       auto it = std::find(mPalette.begin(), mPalette.end(), color);
+       if ( it  == mPalette.end() )
+       {
+          color.paletteNumber = mPalette.size();
+          mPalette.emplace_back(color);
+       }
+       else
+       {
+          color.paletteNumber = it - mPalette.begin();
+       }
+    }
+   
 protected:
     std::unordered_map<std::string, VInterpolator *> mInterpolatorCache;
     std::shared_ptr<model::Composition>              mComposition;
@@ -370,6 +386,7 @@ protected:
     std::vector<model::Layer *>                      mLayersToUpdate;
     std::string                                      mDirPath;
     void                                             SkipOut(int depth);
+    std::vector<model::Color>                        mPalette;
 };
 
 LookaheadParserHandler::LookaheadParserHandler(char *str)
@@ -1886,6 +1903,7 @@ void LottieParserImpl::getValue(model::Color &color)
     color.r = val[0];
     color.g = val[1];
     color.b = val[2];
+    addColorToPalette(color);
 }
 
 void LottieParserImpl::getValue(model::Gradient::Data &grad)


### PR DESCRIPTION
This PR adds support for replacing the colors of a Lottie file on the fly.  The basic idea is the following:
1.  When the Lottie file is parsed, a color palette containing each unique color found in the file is generated.
2. At render time, the client can supply a vector of replacement colors.  When colors are retrieved from the model, the replacement is used if it exists. 

The ugliest part of this is the `static std::vector<Color> s_ReplacementColors;`.   When we evaluate a value in the model we do not have access to the `Composition` or `Animation` that we are working on  Using a global variable allowed me to accomplish the goal of replacing colors without have to do a huge modification to the code base.

I also needed to add some logic to force rlottie to redraw when the colors change.  The code does a good job of only redrawing when necessary, and we need to explicitly set things as dirty when colors change.