### PR TITLE
Reapply TechSmit-specific commits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ target_link_libraries(rlottie
                         "${CMAKE_THREAD_LIBS_INIT}"
                      )
 
-if (NOT APPLE AND NOT WIN32)
+if (NOT APPLE AND NOT WIN32 AND NOT EMSCRIPTEN)
     target_link_libraries(rlottie
                         PRIVATE
                             "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/rlottie.expmap"
@@ -101,7 +101,12 @@ if (LOTTIE_MODULE)
 endif()
 
 if (NOT LOTTIE_ASAN)
-    if(APPLE)
+    if(EMSCRIPTEN)
+        target_link_libraries(rlottie
+                            PUBLIC
+                                 "-Wl"
+                              )
+    elseif(APPLE)
         target_link_libraries(rlottie
                             PUBLIC
                                  "-Wl, -undefined error"
@@ -133,6 +138,11 @@ endif()
 if (NOT LIB_INSTALL_DIR)
     set (LIB_INSTALL_DIR "/usr/lib")
 endif (NOT LIB_INSTALL_DIR)
+
+if(NOT EMSCRIPTEN)
+    generate_dll_rc_filepath(rlottie ${DLL_PRODUCT_NUMBER} ${DLL_PRODUCT_VERSION} ${DLL_BUILD_NUMBER} 2021)
+    target_sources(rlottie PRIVATE ${rlottie_RCFILEPATH})
+endif()
 
 #declare source and include files
 add_subdirectory(inc)

--- a/inc/rlottie.h
+++ b/inc/rlottie.h
@@ -487,6 +487,9 @@ public:
      */
     ~Animation();
 
+    std::vector<Color> colorPalette() const;
+    void setReplacementColors(const std::vector<Color>& replacementColors);
+   
 private:
     void setValue(Color_Type, Property, const std::string &, Color);
     void setValue(Float_Type, Property, const std::string &, float);

--- a/src/lottie/lottieitem.cpp
+++ b/src/lottie/lottieitem.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All rights reserved.
 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -1488,4 +1488,10 @@ void renderer::Repeater::renderList(std::vector<VDrawable *> &list)
 {
     if (mHidden) return;
     return renderer::Group::renderList(list);
+}
+
+void renderer::Composition::setDirty()
+{
+    mCurFrameNo = -1;
+    mRootLayer->setDirty();
 }

--- a/src/lottie/lottieitem.h
+++ b/src/lottie/lottieitem.h
@@ -196,6 +196,7 @@ public:
     const LOTLayerNode *renderTree() const;
     bool                render(const rlottie::Surface &surface);
     void                setValue(const std::string &keypath, LOTVariant &value);
+    void                setDirty();
 
 private:
     SurfaceCache                        mSurfaceCache;
@@ -241,6 +242,7 @@ public:
     const char *                 name() const { return mLayerData->name(); }
     virtual bool resolveKeyPath(LOTKeyPath &keyPath, uint32_t depth,
                                 LOTVariant &value);
+    virtual void setDirty() { mDirtyFlag = DirtyFlagBit::All; }
 
 protected:
     virtual void   preprocessStage(const VRect &clip) = 0;
@@ -281,7 +283,13 @@ public:
 protected:
     void preprocessStage(const VRect &clip) final;
     void updateContent() final;
-
+    void setDirty() override
+    {
+       Layer::setDirty();
+       for ( auto layer : mLayers )
+          layer->setDirty();
+    }
+   
 private:
     void renderHelper(VPainter *painter, const VRle &mask, const VRle &matteRle,
                       SurfaceCache &cache);

--- a/src/lottie/lottiemodel.cpp
+++ b/src/lottie/lottiemodel.cpp
@@ -363,3 +363,5 @@ std::vector<LayerInfo> model::Composition::layerInfoList() const
 
     return result;
 }
+
+std::vector<model::Color> model::Color::s_ReplacementColors;

--- a/src/lottie/lottiemodel.h
+++ b/src/lottie/lottiemodel.h
@@ -77,11 +77,17 @@ public:
     }
     friend inline Color operator+(const Color &c1, const Color &c2);
     friend inline Color operator-(const Color &c1, const Color &c2);
-
+    bool operator==(const Color color) const
+    {
+       return r == color.r && g == color.g && b == color.b;
+    }
+   
 public:
     float r{1};
     float g{1};
     float b{1};
+    int paletteNumber{-1};
+    static std::vector<Color> s_ReplacementColors;
 };
 
 inline Color operator-(const Color &c1, const Color &c2)
@@ -328,7 +334,15 @@ public:
 
     T value(int frameNo) const
     {
-        return isStatic() ? value() : animation().value(frameNo);
+       auto result = isStatic() ? value() : animation().value(frameNo);
+       if constexpr (std::is_same<T, Color>::value)
+       {
+          if (result.paletteNumber >= 0 && result.paletteNumber < Color::s_ReplacementColors.size())
+          {
+             return Color::s_ReplacementColors[result.paletteNumber];
+          }
+       }
+       return result;
     }
 
     // special function only for type T=PathData
@@ -570,6 +584,7 @@ public:
     std::vector<Marker> mMarkers;
     VArenaAlloc         mArenaAlloc{2048};
     Stats               mStats;
+    std::vector<Color>  mColorPalette;
 };
 
 class Transform : public Object {

--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -217,6 +217,8 @@ public:
 
     std::shared_ptr<model::Composition> composition() const
     {
+        if (mComposition)
+           mComposition->mColorPalette = mPalette;
         return mComposition;
     }
     void             parseComposition();
@@ -362,6 +364,20 @@ private:
         }
     } mPathInfo;
 
+    void addColorToPalette(model::Color & color)
+    {
+       auto it = std::find(mPalette.begin(), mPalette.end(), color);
+       if ( it  == mPalette.end() )
+       {
+          color.paletteNumber = mPalette.size();
+          mPalette.emplace_back(color);
+       }
+       else
+       {
+          color.paletteNumber = it - mPalette.begin();
+       }
+    }
+   
 protected:
     std::unordered_map<std::string, VInterpolator *> mInterpolatorCache;
     std::shared_ptr<model::Composition>              mComposition;
@@ -370,6 +386,7 @@ protected:
     std::vector<model::Layer *>                      mLayersToUpdate;
     std::string                                      mDirPath;
     void                                             SkipOut(int depth);
+    std::vector<model::Color>                        mPalette;
 };
 
 LookaheadParserHandler::LookaheadParserHandler(char *str)
@@ -1886,6 +1903,7 @@ void LottieParserImpl::getValue(model::Color &color)
     color.r = val[0];
     color.g = val[1];
     color.b = val[2];
+    addColorToPalette(color);
 }
 
 void LottieParserImpl::getValue(model::Gradient::Data &grad)

--- a/src/vector/vdrawhelper.cpp
+++ b/src/vector/vdrawhelper.cpp
@@ -754,7 +754,7 @@ void VSpanData::updateSpanFunc()
     }
 }
 
-#if !defined(__SSE2__) && !defined(__ARM_NEON__)
+#if !defined(__SSE2__)
 void memfill32(uint32_t *dest, uint32_t value, int length)
 {
     // let compiler do the auto vectorization.

--- a/src/vector/vdrawhelper_common.cpp
+++ b/src/vector/vdrawhelper_common.cpp
@@ -180,9 +180,9 @@ RenderFuncTable::RenderFuncTable()
     updateSrc(BlendMode::DestIn, src_DestinationIn);
     updateSrc(BlendMode::DestOut, src_DestinationOut);
 
-#if defined(__ARM_NEON__)
-    neon();
-#endif
+//#if defined(__ARM_NEON__)
+//    neon();
+//#endif
 #if defined(__SSE2__)
     sse();
 #endif

--- a/src/vector/vdrawhelper_neon.cpp
+++ b/src/vector/vdrawhelper_neon.cpp
@@ -1,33 +1,33 @@
-#if defined(__ARM_NEON__)
-
-#include "vdrawhelper.h"
-
-extern "C" void pixman_composite_src_n_8888_asm_neon(int32_t w, int32_t h,
-                                                     uint32_t *dst,
-                                                     int32_t   dst_stride,
-                                                     uint32_t  src);
-
-extern "C" void pixman_composite_over_n_8888_asm_neon(int32_t w, int32_t h,
-                                                      uint32_t *dst,
-                                                      int32_t   dst_stride,
-                                                      uint32_t  src);
-
-void memfill32(uint32_t *dest, uint32_t value, int length)
-{
-    pixman_composite_src_n_8888_asm_neon(length, 1, dest, length, value);
-}
-
-static void color_SourceOver(uint32_t *dest, int length,
-                                      uint32_t color,
-                                     uint32_t const_alpha)
-{
-    if (const_alpha != 255) color = BYTE_MUL(color, const_alpha);
-
-    pixman_composite_over_n_8888_asm_neon(length, 1, dest, length, color);
-}
-
-void RenderFuncTable::neon()
-{
-    updateColor(BlendMode::Src , color_SourceOver);
-}
-#endif
+//#if defined(__ARM_NEON__)
+//
+//#include "vdrawhelper.h"
+//
+//extern "C" void pixman_composite_src_n_8888_asm_neon(int32_t w, int32_t h,
+//                                                     uint32_t *dst,
+//                                                     int32_t   dst_stride,
+//                                                     uint32_t  src);
+//
+//extern "C" void pixman_composite_over_n_8888_asm_neon(int32_t w, int32_t h,
+//                                                      uint32_t *dst,
+//                                                      int32_t   dst_stride,
+//                                                      uint32_t  src);
+//
+//void memfill32(uint32_t *dest, uint32_t value, int length)
+//{
+//    pixman_composite_src_n_8888_asm_neon(length, 1, dest, length, value);
+//}
+//
+//static void color_SourceOver(uint32_t *dest, int length,
+//                                      uint32_t color,
+//                                     uint32_t const_alpha)
+//{
+//    if (const_alpha != 255) color = BYTE_MUL(color, const_alpha);
+//
+//    pixman_composite_over_n_8888_asm_neon(length, 1, dest, length, color);
+//}
+//
+//void RenderFuncTable::neon()
+//{
+//    updateColor(BlendMode::Src , color_SourceOver);
+//}
+//#endif


### PR DESCRIPTION
I've resynced TechSmith/rlottie to the latest Samsung/rlottie. This PR reapplies the TechSmith-specific commits needed for:
* Disabling NEON optimizations (for Apple Silicon support)
* Feature: Replaceable colors in a Lottie file
* Properly generating an rc file for Windows
* Support building rlottie in an EMSCRIPTEN environment