### PR TITLE
Fix MSVC warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,6 @@ if(MSVC)
     target_compile_options(rlottie
                         PUBLIC
                         PRIVATE
-                            /std:c++14
-                            /EHs-c- # disable exceptions
                             /GR- # disable RTTI
                             /W3
                         )
@@ -60,8 +58,6 @@ else()
     target_compile_options(rlottie
                         PUBLIC
                         PRIVATE
-                            -std=c++14
-                            -fno-exceptions
                             -fno-unwind-tables
                             -fno-asynchronous-unwind-tables
                             -fno-rtti


### PR DESCRIPTION
by removing exception disabling and not forcing c++14