### PR TITLE
CMake 4 Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.3 )
+cmake_minimum_required( VERSION 3.5 )
 
 #declare project
 project( rlottie VERSION 0.2 LANGUAGES C CXX ASM)


### PR DESCRIPTION
## Introduction

CMake 4 (and higher) will error if specified supporting below CMake `3.5`:
![image](https://github.com/user-attachments/assets/67f45f1b-901e-4a02-ae16-e54417301a61)

This updates just that value.

## Details

The `Master` branch of https://github.com/Samsung/rlottie doesn't appear to have it fixed at this moment:
https://github.com/Samsung/rlottie/blob/e3026b1e1a516fff3c22d2b1b9f26ec864f89a82/CMakeLists.txt#L1

And this is a fork. 

## Testing Notes

My VS seems to generate with these changes.

Hope that helps! :smiley: