### PR TITLE
Fix Windows Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,14 @@ endif()
 set( CMAKE_THREAD_PREFER_PTHREAD TRUE )
 find_package( Threads )
 
+if(WIN32)
+   set( OSSPEC_LIBS Shlwapi.lib )
+endif()
+
 target_link_libraries(rlottie
                     PUBLIC
                         "${CMAKE_THREAD_LIBS_INIT}"
+                        ${OSSPEC_LIBS}
                      )
 
 if (NOT APPLE AND NOT WIN32 AND NOT EMSCRIPTEN)

--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -64,6 +64,15 @@ RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(effc++)
 #endif
 
+#ifdef _WIN32
+#include <windows.h>
+#include <shlwapi.h>
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX MAX_PATH
+#endif
+
 using namespace rapidjson;
 
 using namespace rlottie::internal;
@@ -814,13 +823,27 @@ static std::string convertFromBase64(const std::string &str)
     return b64decode(b64Data, length);
 }
 
+namespace
+{
+   bool Canonicalize(const char *path, char *resolved_path)
+   {
+#ifdef _WIN32
+       return !!PathCanonicalizeA(resolved_path, path);
+#else
+       return realpath(path, resolved_path);
+#endif
+   }
+}
+
 static bool isResourcePathSafe(const std::string& baseDir, const std::string& userPath)
 {
     char resolvedBase[PATH_MAX] = {};
     char resolvedTarget[PATH_MAX] = {};
 
     // Resolve base directory
-    if (!realpath(baseDir.c_str(), resolvedBase)) {
+    if (!Canonicalize(baseDir.c_str(), resolvedBase))
+    {
+
 #ifdef DEBUG_PARSER
         vWarning << "Error: Cannot resolve base path: " << baseDir.c_str();
 #endif
@@ -832,7 +855,7 @@ static bool isResourcePathSafe(const std::string& baseDir, const std::string& us
     if (!baseDir.empty() && baseDir.back() != '/') fullPath += "/";
     fullPath += userPath;
 
-    if (!realpath(fullPath.c_str(), resolvedTarget)) {
+    if (!Canonicalize(fullPath.c_str(), resolvedTarget)) {
 #ifdef DEBUG_PARSER
         vWarning << "Error: Cannot resolve target path: " << fullPath.c_str();
 #endif

--- a/src/lottie/lottieparser.cpp
+++ b/src/lottie/lottieparser.cpp
@@ -67,6 +67,8 @@ RAPIDJSON_DIAG_OFF(effc++)
 #ifdef _WIN32
 #include <windows.h>
 #include <shlwapi.h>
+
+#include <string_view>
 #endif
 
 #ifndef PATH_MAX
@@ -825,10 +827,52 @@ static std::string convertFromBase64(const std::string &str)
 
 namespace
 {
+   #ifdef _WIN32
+   std::wstring ToStdWString( std::string_view str )
+   {
+      std::wstring wstr;
+      int          nchars = ::MultiByteToWideChar(CP_UTF8, 0, str.data(), (int)str.length(), 0, 0);
+      if ( nchars > 0 )
+      {
+        wstr.resize( nchars );
+        ::MultiByteToWideChar( CP_UTF8, 0, str.data(), (int)str.length(),
+                               const_cast<wchar_t *>( wstr.c_str() ),
+                                nchars );
+      }
+
+      return wstr;
+   }
+
+   std::string ToStdString( std::wstring_view wstr )
+   {
+       std::string str;
+       int         nchars = ::WideCharToMultiByte( CP_UTF8, 0, wstr.data(), (int)wstr.length(), NULL, NULL, NULL, NULL );
+       if ( nchars > 0 )
+       {
+           str.resize(nchars);
+           ::WideCharToMultiByte( CP_UTF8, 0, wstr.data(), (int)wstr.length(),
+                                  const_cast<char *>(str.c_str()), nchars, NULL, NULL );
+       }
+
+       return str;
+   }
+   #endif
+
    bool Canonicalize(const char *path, char *resolved_path)
    {
 #ifdef _WIN32
-       return !!PathCanonicalizeA(resolved_path, path);
+       std::wstring wpath = ToStdWString( path );
+       std::wstring wresolved_path;
+       wresolved_path.resize( PATH_MAX );
+       if ( PathCanonicalizeW( wresolved_path.data(), wpath.c_str() ) )
+       {
+           std::string path = ToStdString(wresolved_path);
+           strcpy_s( resolved_path, path.length() * sizeof( char ), path.c_str() );
+
+           return true;
+       }
+
+       return false;
 #else
        return realpath(path, resolved_path);
 #endif


### PR DESCRIPTION
## Introduction

The `rlottie` has a recent commit: https://github.com/Samsung/rlottie/commit/346c9b604b4227b491f38e1c5a4dd43d4f7c45ac from mid-June that uses `PATH_MAX` which isn't defined on Windows.  We need to build with Windows so I added that define.

Also `realpath` is a POSIX function: https://man7.org/linux/man-pages/man3/realpath.3.html so needed the equivalent for Windows.

## Testing Notes

I did run some unit tests but it was client-side; and a harness also client-side to which I didn't even test with any lottie files.

Hope that helps! :smiley: